### PR TITLE
Update download_Yeast_GO_mapping.R

### DIFF
--- a/R/download_Yeast_GO_mapping.R
+++ b/R/download_Yeast_GO_mapping.R
@@ -1,5 +1,5 @@
 download_Yeast_GO_mapping <-
-function(yeast.GO.url='http://downloads.yeastgenome.org/curation/literature/gene_association.sgd.gz'){
+function(yeast.GO.url='http://downloads.yeastgenome.org/curation/literature/gene_association.sgd.gaf.gz'){
   ##### download Yeast Gene Ontology mapping  http://downloads.yeastgenome.org/curation/literature/gene_association.sgd.gz
   GO.assocs.all  <- read.table(textConnection(readLines(gzcon(url(yeast.GO.url))))
                          ,header=FALSE,check.names=FALSE, stringsAsFactors=FALSE, sep="\t", quote=NULL, comment.char ='!'


### PR DESCRIPTION
Had to change the address of the Yeast gene association file
since the maintainer has renamed the file to:
http://downloads.yeastgenome.org/curation/literature/gene_association.sgd.gaf.gz